### PR TITLE
Replace unsupported docker-py with current docker module.

### DIFF
--- a/roles/bootstrap/tasks/init.yml
+++ b/roles/bootstrap/tasks/init.yml
@@ -19,8 +19,11 @@
     name: python-pip
     state: present
 
-- name: make sure docker-py is installed via pip
-  pip: name="docker-py==1.10.6" state=present
+- name: make sure docker-py is NOT installed
+  pip: name="docker-py" state=absent
+
+- name: make sure docker is installed via pip
+  pip: name="docker>=3.4" state=present
 
 - name: clear install directory
   file: path={{ dcos_path_bootstrap }} state=absent


### PR DESCRIPTION
As noted at https://github.com/ansible/ansible/issues/42162 and elsewhere, `docker-py` is no longer maintained, and ansible now requires the use of it's replacement, the PyPI module named simply `docker`. Since these conflict, docker-py must be explicitly removed first.

Without this change, the playbook will not run under Ansible 2.6+.