### PR TITLE
Changing check in cluster update

### DIFF
--- a/roles/node-upgrade/tasks/agent.yml
+++ b/roles/node-upgrade/tasks/agent.yml
@@ -19,7 +19,7 @@
 - name: check if mesos agent reregistered
   uri: url=http://{{ ansible_default_ipv4['address'] }}:5051/metrics/snapshot return_content=true
   register: response
-  until: "'slave\\/registered\":1.0' in response.content"
+  until: "'slave/registered\":1.0' in response.content"
   retries: 12
   delay: 5
   changed_when: false

--- a/roles/node-upgrade/tasks/master.yml
+++ b/roles/node-upgrade/tasks/master.yml
@@ -16,7 +16,7 @@
 - name: check if mesos master recovered
   uri: url=http://{{ ansible_default_ipv4['address'] }}:5050/metrics/snapshot return_content=true
   register: response
-  until: "'registrar\\/log\\/recovered\":1.0' in response.content"
+  until: "'registrar/log/recovered\":1.0' in response.content"
   retries: 12
   delay: 5
   changed_when: false


### PR DESCRIPTION
It seems a check fails for both the masters/nodes when trying to upgrade the cluster.
The answer from the webserver includes the string needed for the test to pass, but the comparison string contains characters ("\\") that are not present in the result, thus making the test fail.
Maybe those are present because they were needed in previous versions ?
I tried updating a cluster from 1.11.4 to 1.12.0 and the only way for it to work was to modify those 2 checks.